### PR TITLE
Fix downloading of renamed

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ npm install duo-package
 
 ```js
 var pkg = new Package('matthewmueller/cheerio', '0.13.x')
-  .auth(process.env.user, process.env.token)
+  .token(process.env.token)
   .directory('components');
 
 co(function *() {
@@ -45,11 +45,11 @@ Package('matthewmueller/uid', 'some/feature');
 Package('matthewmueller/uid', '~0.1.0');
 ```
 
-### Package#auth(user, token)
+### Package#token(token)
 
 authenticate with github. you can create a new token here: https://github.com/settings/tokens/new.
 
-if the `user` and `token` are not present, duo-package will try reading the authentication details from your `~/.netrc`. Here's an example:
+if the `token` is not present, duo-package will try reading the authentication details from your `~/.netrc`. Here's an example:
 
 ```
 machine api.github.com

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,6 @@ var api = 'https://api.github.com';
  */
 
 var auth = netrc('api.github.com') || {
-  login: process.env.GH_USER,
   password: process.env.GH_TOKEN
 };
 
@@ -80,7 +79,7 @@ var auth = netrc('api.github.com') || {
  * Logging
  */
 
-auth.login && auth.password
+auth.password
   ? debug('read auth details from ~/.netrc')
   : debug('could not read auth details from ~/.netrc')
 
@@ -95,8 +94,7 @@ auth.login && auth.password
 function Package(repo, ref) {
   if (!(this instanceof Package)) return new Package(repo, ref);
   this.repo = repo.replace(':', '/');
-  this.token = auth.password || null;
-  this.user = auth.login || null;
+  this.tok = auth.password || null;
   this.setMaxListeners(Infinity);
   this.dir = process.cwd();
   this.ua = 'duo-package';
@@ -153,15 +151,14 @@ Package.prototype.useragent = function(ua) {
 /**
  * Authenticate with github
  *
- * @param {String} user
  * @param {String} token
- * @return {Package} self
+ * @return {String|Package} self
  * @api public
  */
 
-Package.prototype.auth = function(user, token) {
-  this.user = user || this.user;
-  this.token = token || this.token;
+Package.prototype.token = function(token) {
+  if (!token) return this.tok;
+  this.tok = token;
   return this;
 };
 
@@ -173,12 +170,11 @@ Package.prototype.auth = function(user, token) {
  */
 
 Package.prototype.authenticated = function(){
-  var auth = this.user && this.token;
-  if (auth) return this;
+  if (this.tok) return this;
   throw this.error([
     'Github authentication error:',
     'make sure you have ~/.netrc or',
-    'specify $GH_USER=<user> $GH_TOKEN=<token>.'
+    'specify $GH_TOKEN=<token>.'
   ].join(' '));
 };
 
@@ -215,7 +211,7 @@ Package.prototype.resolve = function *() {
   this.debug('resolving');
 
   // resolve
-  var ref = yield resolve(slug, this.user, this.token);
+  var ref = yield resolve(slug, { token: this.tok });
 
   // couldn't resolve
   if (!ref) throw this.error('%s: reference %s not found', this.slug(), this.ref);
@@ -233,18 +229,16 @@ Package.prototype.resolve = function *() {
  * Fetch the tarball from github
  * extracting to `dir`
  *
- * @param {Object} opts
  * @return {Package} self
  * @api public
  */
 
-Package.prototype.fetch = function *(opts) {
+Package.prototype.fetch = function *() {
   this.authenticated();
-  opts = opts || {};
 
   // resolve
   var ref = this.resolved || (yield this.resolve());
-  var url = fmt('%s/repos/%s/tarball/%s', api, this.repo, ref);
+  var url = fmt('https://%s@github.com/%s/archive/%s.tar.gz', this.tok, this.repo, ref);
   var cache = join(cachepath, this.slug() + '.tar.gz');
   var dest = this.path();
 
@@ -292,7 +286,7 @@ Package.prototype.fetch = function *(opts) {
   this.debug('fetching from %s', url);
 
   // download tarball and extract
-  var store = yield this.download(this.options(url));
+  var store = yield this.download(url);
 
   // cache, extract
   var cacheable = this._cache && semver.validRange(ref);
@@ -367,17 +361,22 @@ Package.prototype.options = function(url, other){
  * Reliably download the package.
  * Returns a store to be piped around.
  *
- * @param {Object} opts
+ * @param {String} url
  * @return {Function}
  * @api private
  */
 
-Package.prototype.download = function(opts) {
+Package.prototype.download = function(url) {
   var store = enstore();
   var gzip = store.createWriteStream();
+  var opts = { headers: {} };
   var self = this;
   var prev = 0;
   var len = 0;
+
+  // options
+  opts.headers['User-Agent'] = this.ua;
+  opts.url = url;
 
   return function(fn) {
     var req = request(opts);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "co-fs": "^1.2.0",
     "debug": "^0.8.0",
     "enstore": "0.0.2",
-    "gh-resolve": "^2.0.2",
+    "gh-resolve": "^3.0.0",
     "gnode": "0.0.8",
     "node-netrc": "0.0.1",
     "request": "^2.36.0",

--- a/test/index.js
+++ b/test/index.js
@@ -51,8 +51,7 @@ describe('duo-package', function(){
     var pkg = Package('component/type', '1.0.0');
     var a, b;
 
-    pkg.user = null;
-    pkg.token = null;
+    pkg.tok = null;
 
     try {
       yield pkg.fetch();
@@ -71,7 +70,7 @@ describe('duo-package', function(){
       'component-type@1.0.0:',
       'Github authentication error:',
       'make sure you have ~/.netrc or',
-      'specify $GH_USER=<user> $GH_TOKEN=<token>.'
+      'specify $GH_TOKEN=<token>.'
     ].join(' '));
   })
 


### PR DESCRIPTION
This PR does a couple things:
- Updated `gh-resolve` which uses `git ls-remote` instead of the API (thanks @jonathanong)
- Changed `Package#auth(user, token)` to `Package#token(token)` since `user` doesn't matter anymore in auth.
- Changed download API to use `archives` instead of `api.github.com` (thanks @cristiandouce)
