### PR TITLE
package: Update debug and gnode

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "dependencies": {
     "co-fs": "^1.2.0",
-    "debug": "^0.7.4",
+    "debug": "^2.0.0",
     "enstore": "0.0.2",
     "gh-resolve": "^3.0.3",
-    "gnode": "0.0.8",
+    "gnode": "^0.1.0",
     "mkdirp": "^0.5.0",
     "node-netrc": "0.0.1",
     "request": "^2.36.0",


### PR DESCRIPTION
- debug@2 uses `stderr` again, so we may as well use the latest version
- gnode@0.1 compensates for its upstream dependency (regenerator)'s api
  change
