### PR TITLE
lib: Remove `.netrc` magic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,6 @@ var write = require('fs').createWriteStream;
 var read = require('fs').createReadStream;
 var resolve = require('gh-resolve');
 var mkdir = require('mkdirp').sync;
-var netrc = require('node-netrc');
 var fmt = require('util').format;
 var enstore = require('enstore');
 var tmp = require('os').tmpdir();
@@ -55,22 +54,6 @@ var cachepath = join(tmp, 'duo');
 mkdir(cachepath);
 
 /**
- * auth from ~/.netrc
- */
-
-var auth = netrc('api.github.com') || {
-  password: process.env.GH_TOKEN
-};
-
-/**
- * Logging
- */
-
-auth.password
-  ? debug('read auth details from ~/.netrc')
-  : debug('could not read auth details from ~/.netrc');
-
-/**
  * Unauthorized string
  */
 
@@ -88,7 +71,7 @@ var unauthorized = 'You have not authenticated and this repo may be private.'
 function Package(repo, ref) {
   if (!(this instanceof Package)) return new Package(repo, ref);
   this.repo = repo.replace(':', '/');
-  this.tok = auth.password || null;
+  this.tok = null;
   this.setMaxListeners(Infinity);
   this.dir = process.cwd();
   this.ua = 'duo-package';

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "gh-resolve": "^3.0.3",
     "gnode": "^0.1.0",
     "mkdirp": "^0.5.0",
-    "node-netrc": "0.0.1",
     "request": "^2.36.0",
     "semver": "~2.3.0",
     "tar-fs": "^0.4.1",
@@ -27,6 +26,7 @@
     "co-mocha": "^1.1.0",
     "mkdirp": "^0.5.0",
     "mocha": "^2.0.1",
+    "node-netrc": "0.0.1",
     "rimraf": "^2.2.8"
   },
   "main": "index.js"

--- a/test/index.js
+++ b/test/index.js
@@ -3,10 +3,17 @@ var exists = require('fs').existsSync;
 var mkdirp = require('mkdirp').sync;
 var rimraf = require('rimraf').sync;
 var assert = require('assert');
+var netrc = require('node-netrc');
 var Package = require('..');
 
 describe('duo-package', function(){
   var pkgs = ['component/type@master', 'component/type@1.0.0', 'component/emitter@master'];
+  var token = null;
+
+  before(function(){
+    var auth = netrc('api.github.com') || {};
+    token = auth.password;
+  });
 
   beforeEach(function(){
     mkdirp(__dirname + '/tmp');
@@ -24,6 +31,7 @@ describe('duo-package', function(){
     yield pkgs.map(function(pkg){
       var parts = pkg.split('@');
       pkg = Package(parts[0], parts[1]);
+      pkg.token(token);
       pkg.directory(__dirname + '/tmp');
       return pkg.fetch();
     });
@@ -36,6 +44,7 @@ describe('duo-package', function(){
   it('should error when package is not found (status code: 406)', function*(){
     var pkg = Package('component/406', '1.0.0');
     pkg.directory(__dirname + '/tmp');
+    pkg.token(token);
     var msg;
 
     try {
@@ -52,6 +61,7 @@ describe('duo-package', function(){
     this.timeout(60000);
     var pkg = Package('twbs/bootstrap', 'v3.2.0');
     pkg.directory(__dirname + '/tmp');
+    pkg.token(token);
     yield pkg.fetch();
     assert(exists(__dirname + '/tmp/twbs-bootstrap@v3.2.0/package.json'));
   })
@@ -62,9 +72,13 @@ describe('duo-package', function(){
     var c = Package('component/tip', '1.x');
     var d = Package('component/tip', '1.x');
     a.directory(__dirname + '/tmp');
+    a.token(token);
     b.directory(__dirname + '/tmp');
+    b.token(token);
     c.directory(__dirname + '/tmp');
+    c.token(token);
     d.directory(__dirname + '/tmp');
+    d.token(token);
     yield [a.fetch(), b.fetch(), c.fetch(), d.fetch()];
     assert(exists(__dirname + '/tmp/component-tip@1.0.3/component.json'));
   })
@@ -72,12 +86,14 @@ describe('duo-package', function(){
   it('should work with renamed repos', function *() {
     var pkg = Package('component/get-document', '0.1.0');
     pkg.directory(__dirname + '/tmp')
+    pkg.token(token);
     yield pkg.fetch();
     assert(exists(__dirname + '/tmp/component-get-document@0.1.0/component.json'));
   })
 
   it('should work with callbacks', function(done) {
     var pkg = Package('component/emitter', '0.0.x');
+    pkg.token(token);
     pkg.resolve(function(err, ref) {
       if (err) done(err);
       assert('0.0.6' == ref);
@@ -87,6 +103,7 @@ describe('duo-package', function(){
 
   it('should work on weird forked semvers', function(done){
     var pkg = Package('segmentio/marked', '*');
+    pkg.token(token);
     pkg.resolve(function (err, ref) {
       if (err) return done(err);
       assert(/v[.\d]+/.test(ref));


### PR DESCRIPTION
This patch removes all `~/.netrc`-related logic from duo-package
entirely.  Configuration file parsing should be handled upstream in
`duo(1)`, not in a library.

Removing this magic will make adding credentials for other providers
significantly easier (and more verbose) when we add support for such
behaviour.

Closes #50.
