### PR TITLE
Clean cache

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,7 @@ var enstore = require('enstore');
 var tmp = require('os').tmpdir();
 var unyield = require('unyield');
 var thunk = require('thunkify');
+var rm = require('rimraf-then');
 var semver = require('semver');
 var tar = require('tar-fs');
 var path = require('path');
@@ -86,6 +87,20 @@ function Package(repo, ref) {
  */
 
 Package.prototype.__proto__ = Emitter.prototype;
+
+/**
+ * Static property for accessing the cache location.
+ */
+
+Package.cachepath = cachepath;
+
+/**
+ * Static method for cleaning the cache.
+ */
+
+Package.cleanCache = function *() {
+  yield rm(cachepath);
+};
 
 /**
  * Set the directory to install into

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "gnode": "^0.1.0",
     "mkdirp": "^0.5.0",
     "request": "^2.36.0",
+    "rimraf-then": "^1.0.0",
     "semver": "~2.3.0",
     "tar-fs": "^0.4.1",
     "thunkify": "0.0.1",

--- a/test/index.js
+++ b/test/index.js
@@ -125,4 +125,12 @@ describe('duo-package', function(){
 
     // TODO: figure out a way to test private modules
   })
+
+  describe('cache', function () {
+    it('should clean the tmp dir cache', function *() {
+      assert(exists(Package.cachepath));
+      yield Package.cleanCache();
+      assert(!exists(Package.cachepath));
+    });
+  });
 })


### PR DESCRIPTION
This exposes a way to clean the cache that `duo-package` uses. (ie: `path.join(os.tmpdir(), 'duo')`)

Once this is merged and released, I have a branch ready within `duojs/duo` that will finish out the support for duojs/duo#437.