### PR TITLE
adding retry support to download

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ node_js:
 script: "make test"
 env:
   global:
-    - secure: JYP1xsnZC3TqJamdfHNy9smz+NnfaDZZKyVqI8+9SFr0Jf2Q8886zfEBO+vKImGdOgTO++YxmalE1KAz4GsNhw02cJuyL2rHxRIAjvLDQmfKa5L+Aw3E7mnuOiomWZ8V1GOxT57blqT6Lsrov8QFiBal5RuowaBheFptESDpXPI=
+    - secure: WdPVuaRFwTYKNFx7goA36QGwCPDATLT1PUL3XLilZX/AlfjgRICZn7/55WnSk7IJtkexYA4uuXlqIqefWMEACHW0gzwYrQES90wRonLUPYEbUUlfhXJFKWE1XCQRXDUDk1vX+XaIjsH52HcYGDbfauU8sRvrzOq1kPd5R2jWkRE=

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,9 +3,9 @@
  * Module dependencies
  */
 
-var debug = require('debug')('duo-package');
 var Emitter = require('events').EventEmitter;
 var write = require('fs').createWriteStream;
+var debug = require('debug')('duo-package');
 var read = require('fs').createReadStream;
 var resolve = require('gh-resolve');
 var mkdir = require('mkdirp-then');
@@ -79,6 +79,7 @@ function Package(repo, ref) {
   this.resolved = false;
   this.ref = ref || '*';
   this._cache = true;
+  this.retries = 3;
   Emitter.call(this);
 }
 
@@ -350,7 +351,7 @@ Package.prototype.download = function(url) {
 
       // Ensure that we have the write status code
       if (status < 200 || status >= 300) {
-        var statusError = 406 == status && !tok
+        var statusError = 404 == status && !tok
           ? self.error('returned with status code: %s. %s', status, unauthorized)
           : self.error('returned with status code: %s', status);
         return fn(statusError);
@@ -374,7 +375,13 @@ Package.prototype.download = function(url) {
     });
 
     function error(err) {
-      return fn(self.error(err));
+      self.debug('error encountered: %s', err.message);
+      if (self.retries-- <= 0) { // after all retry attempts
+        fn(self.error(err));
+      } else {
+        self.debug('retry');
+        self.download(url);
+      }
     }
   };
 };

--- a/test/index.js
+++ b/test/index.js
@@ -41,8 +41,8 @@ describe('duo-package', function(){
     assert(yield exists(__dirname + '/tmp/component-emitter@master/component.json'));
   })
 
-  it('should error when package is not found (status code: 406)', function*(){
-    var pkg = Package('component/406', '1.0.0');
+  it('should error when package is not found (status code: 404)', function*(){
+    var pkg = Package('component/404', '1.0.0');
     pkg.directory(__dirname + '/tmp');
     pkg.token(token);
     var msg;
@@ -53,8 +53,7 @@ describe('duo-package', function(){
       msg = e.message;
     }
 
-
-    assert(~msg.indexOf('component-406@1.0.0: returned with status code: 406'));
+    assert(~msg.indexOf('component-404@1.0.0: returned with status code: 404'));
   })
 
   it('should work with bootstrap', function *() {
@@ -118,7 +117,7 @@ describe('duo-package', function(){
       pkg.token(null);
       pkg.fetch(function(err) {
         assert(err);
-        assert.equal(err.message, 'matthewmueller-wordsmith@master: returned with status code: 406. You have not authenticated and this repo may be private. Make sure you have a ~/.netrc entry or specify $GH_TOKEN=<token>.');
+        assert.equal(err.message, 'matthewmueller-wordsmith@master: returned with status code: 404. You have not authenticated and this repo may be private. Make sure you have a ~/.netrc entry or specify $GH_TOKEN=<token>.');
         done();
       });
     });


### PR DESCRIPTION
This allows `Package#download()` to retry up to 3 times. (4 attempts in all)

**Note:** this only affects transmission errors, such as "socket hang up" or "timed out". When an HTTP response is received, even if it is an error, it will not retry that.

This gets most of the way there to addressing #10 , but doesn't add an explicit timeout. (we could "fail fast" and retry after 1s, but that is not what is implemented here.)

/cc @duojs/owners 