### PR TITLE
Improved cache support, using updated internal modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,6 @@ var tmp = require('os').tmpdir();
 var unyield = require('unyield');
 var rm = require('rimraf-then');
 var join = require('path').join;
-var semver = require('semver');
 var tar = require('tar-fs');
 var zlib = require('zlib');
 var util = require('util');

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,15 +13,13 @@ var fmt = require('util').format;
 var enstore = require('enstore');
 var tmp = require('os').tmpdir();
 var unyield = require('unyield');
-var thunk = require('thunkify');
 var rm = require('rimraf-then');
+var join = require('path').join;
 var semver = require('semver');
 var tar = require('tar-fs');
-var path = require('path');
 var zlib = require('zlib');
 var util = require('util');
 var fs = require('co-fs');
-var join = path.join;
 
 /**
  * Export `Package`
@@ -30,22 +28,10 @@ var join = path.join;
 module.exports = Package;
 
 /**
- * Thunkify functions
- */
-
-resolve = thunk(resolve);
-
-/**
  * Inflight
  */
 
 var inflight = {};
-
-/**
- * Refs.
- */
-
-var refs = {};
 
 /**
  * Cache tarballs in "$tmp/duo"
@@ -72,6 +58,7 @@ var unauthorized = 'You have not authenticated and this repo may be private.'
 
 function Package(repo, ref) {
   if (!(this instanceof Package)) return new Package(repo, ref);
+
   this.repo = repo.replace(':', '/');
   this.tok = null;
   this.setMaxListeners(Infinity);
@@ -79,7 +66,6 @@ function Package(repo, ref) {
   this.ua = 'duo-package';
   this.resolved = false;
   this.ref = ref || '*';
-  this._cache = true;
   this.retries = 3;
   Emitter.call(this);
 }
@@ -157,6 +143,20 @@ Package.prototype.token = function(token) {
 };
 
 /**
+ * Set the cache instance to use.
+ *
+ * @param {Cache} cache
+ * @return {Cache|Package}
+ * @api public
+ */
+
+Package.prototype.cache = function (cache) {
+  if (!arguments.length) return this._cache;
+  this._cache = cache;
+  return this;
+};
+
+/**
  * Resolve the reference on github
  *
  * @return {String}
@@ -164,18 +164,6 @@ Package.prototype.token = function(token) {
  */
 
 Package.prototype.resolve = unyield(function *() {
-  // if it's a valid version
-  // or invalid range, no need to resolve.
-  if (semver.valid(this.ref) || !semver.validRange(this.ref)) {
-    this.debug('don\'t need to resolve %s', this.ref);
-    this.resolved = this.ref;
-    return this.resolved;
-  }
-
-  // check if ref is in the cache
-  var slug = this.repo + '@' + this.ref;
-  this.resolved = this.resolved || cached(this.repo, this.ref);
-
   // resolved
   if (this.resolved) {
     this.debug('resolved from cache %s', this.resolved);
@@ -187,14 +175,13 @@ Package.prototype.resolve = unyield(function *() {
   this.debug('resolving');
 
   // resolve
-  var ref = yield resolve(slug, { token: this.tok });
-
-  // couldn't resolve
-  if (!ref) throw this.error('%s: reference %s not found', this.slug(), this.ref);
+  var ref = yield resolve(this.repo + '@' + this.ref, {
+    token: this.token(),
+    cache: this.cache()
+  });
 
   // resolved
   this.resolved = ref.name;
-  (refs[this.repo] = refs[this.repo] || []).push(ref.name);
   this.debug('resolved');
   this.emit('resolve');
 
@@ -210,9 +197,8 @@ Package.prototype.resolve = unyield(function *() {
  */
 
 Package.prototype.fetch = unyield(function *() {
-
   // resolve
-  var ref = this.resolved || (yield this.resolve());
+  var ref = yield this.resolve();
   var token = this.tok ? this.tok + '@' : '';
   var url = fmt('https://%sgithub.com/%s/archive/%s.tar.gz', token, this.repo, ref);
   var cache = join(cachepath, this.slug() + '.tar.gz');
@@ -229,7 +215,6 @@ Package.prototype.fetch = unyield(function *() {
 
   // check if directory already exists
   if (yield this.exists()) {
-
     // already exists
     this.emit('fetching');
     this.debug('already exists');
@@ -241,7 +226,6 @@ Package.prototype.fetch = unyield(function *() {
 
   // check the cache
   if (yield exists(cache)) {
-
     // extracting
     this.emit('fetching');
     this.emit('installing');
@@ -268,13 +252,10 @@ Package.prototype.fetch = unyield(function *() {
   var store = yield this.download(url);
 
   // cache, extract
-  var cacheable = this._cache && semver.validRange(ref);
-  var gens = [];
-
-  if (cacheable) gens.push(this.write(store, cache));
-  gens.push(this.extract(store, dest));
-
-  yield gens;
+  yield [
+    this.write(store, cache),
+    this.extract(store, dest)
+  ];
 
   // fetch
   this.emit('fetch');
@@ -471,27 +452,6 @@ Package.prototype.error = function(msg) {
   var args = [].slice.call(arguments, 1);
   return new Error(fmt.apply(null, [msg].concat(args)));
 };
-
-/**
- * Get a cached `repo`, `ref`.
- *
- * @param {String} repo
- * @param {String} ref
- * @return {String}
- * @api private
- */
-
-function cached(repo, ref){
-  var revs = refs[repo] || [];
-
-  for (var i = 0; i < revs.length; ++i) {
-    try {
-      if (semver.satisfies(revs[i], ref)) return revs[i];
-    } catch (e) {
-      if (revs[i] === ref) return revs[i];
-    }
-  }
-}
 
 /**
  * Display the curl request

--- a/package.json
+++ b/package.json
@@ -15,13 +15,12 @@
     "co-fs": "^1.2.0",
     "debug": "^2.0.0",
     "enstore": "0.0.2",
-    "gh-resolve": "^3.0.3",
+    "gh-resolve": "^5.1.0",
     "mkdirp": "^0.5.1",
     "request": "^2.36.0",
     "rimraf-then": "^1.0.0",
     "semver": "~2.3.0",
     "tar-fs": "^0.4.1",
-    "thunkify": "0.0.1",
     "unyield": "0.0.1"
   },
   "devDependencies": {
@@ -31,6 +30,7 @@
     "eslint": "^0.24.0",
     "eslint-config-duo": "0.0.1",
     "gnode": "^0.1.1",
+    "mkdirp-then": "^1.1.0",
     "mocha": "^2.0.1",
     "node-netrc": "0.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "mkdirp": "^0.5.1",
     "request": "^2.36.0",
     "rimraf-then": "^1.0.0",
-    "semver": "~2.3.0",
     "tar-fs": "^0.4.1",
     "unyield": "0.0.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -113,21 +113,6 @@ describe('duo-package', function(){
     });
   });
 
-  describe('private modules', function() {
-    it('should throw a meaningful error when not authenticated', function (done) {
-      var pkg = Package('matthewmueller/wordsmith', 'master');
-      pkg.directory(tmp);
-      pkg.token(null);
-      pkg.fetch(function(err) {
-        assert(err);
-        assert.equal(err.message, 'unable to resolve matthewmueller/wordsmith@master');
-        done();
-      });
-    });
-
-    // TODO: figure out a way to test private modules
-  });
-
   describe('cache', function () {
     it('should clean the tmp dir cache', function *() {
       assert(yield exists(Package.cachepath));

--- a/test/index.js
+++ b/test/index.js
@@ -7,6 +7,7 @@ var Package = require('..');
 var path = require('path');
 var rimraf = require('rimraf-then');
 
+var auth = netrc('api.github.com') || { token: process.env.GH_TOKEN };
 var tmp = path.join(__dirname, 'tmp');
 
 describe('duo-package', function(){
@@ -14,8 +15,7 @@ describe('duo-package', function(){
   var token = null;
 
   before(function(){
-    var auth = netrc('api.github.com') || {};
-    token = auth.password;
+    token = auth.token || auth.password;
   });
 
   beforeEach(function*(){

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,7 @@ describe('duo-package', function(){
       msg = e.message;
     }
 
-    assert(~msg.indexOf('component-404@1.0.0: returned with status code: 404'));
+    assert.equal(msg, 'unable to resolve component/404@1.0.0');
   });
 
   it('should work with bootstrap', function *() {
@@ -120,7 +120,7 @@ describe('duo-package', function(){
       pkg.token(null);
       pkg.fetch(function(err) {
         assert(err);
-        assert.equal(err.message, 'matthewmueller-wordsmith@master: returned with status code: 404. You have not authenticated and this repo may be private. Make sure you have a ~/.netrc entry or specify $GH_TOKEN=<token>.');
+        assert.equal(err.message, 'unable to resolve matthewmueller/wordsmith@master');
         done();
       });
     });


### PR DESCRIPTION
This continues the work from around duo, starting to finally come together here. I'm updating `gh-resolve`, along with all the implications that has for caching and performance improvements.

This cleaned up the internals here a bit, since a lot of the caching of GH API calls is now handled by `gh-resolve` (which is using in-memory + `duo-cache` internally) With these changes, the tests for `duo@master` still pass! :D 