### PR TITLE
lib: provide `this.repo` when emitting "resolve"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -195,7 +195,7 @@ Package.prototype.resolve = unyield(function *() {
   this.resolving = false;
   this.resolved = ref.name;
   this.debug('resolved', ref.name);
-  this.emit('resolve', ref.name);
+  this.emit('resolve', ref.name, this.repo);
 
   return ref.name;
 });


### PR DESCRIPTION
This will allow us to do something like:

``` js
const duo = new Duo(root)
duo.on('resolve', function(version, module) {
  console.log(`${module}@${version}`)
})
```

@dominicbarnes 
